### PR TITLE
Update to v6.9.2

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,8 +2,8 @@
 c_stdlib_version:  # [not linux]
   - 12.0           # [osx]
   - 2022.12        # [win]
-OSX_SDK_VER:
-  - 13.3
+OSX_SDK_VER:       # [osx]
+  - 13.3           # [osx]
 
 # https://doc.qt.io/qt-6/windows.html
 c_compiler:    # [win]
@@ -18,11 +18,7 @@ c_compiler_version:    # [osx]
 cxx_compiler_version:  # [osx]
   - 17                 # [osx]
 
-# Need at least a 12.0 host or else tests will fail.
-extra_labels_for_os:
-  osx-arm64: [ventura]
-
 # Have to leave this for now or else the overlinking checks fail when we revert back to the aggregate CBC and use the
-# 11.1 sysroot.
+# 12.1 sysroot.
 CONDA_BUILD_SYSROOT:
   - /Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk  # [osx and arm64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "qttranslations" %}
-{% set version = "6.9.1" %}
+{% set version = "6.9.2" %}
 
 package:
   name: {{ name }}
@@ -7,12 +7,11 @@ package:
 
 source:
   - url: https://download.qt.io/official_releases/qt/{{ version.rpartition('.')[0] }}/{{ version }}/submodules/{{ name }}-everywhere-src-{{ version }}.tar.xz
-    sha256: 9761a1a555f447cdeba79fdec6a705dee8a7882ac10c12e85f49467ddd01a741
+    sha256: c73bb6281ed365c0f954f4b1b6e1b13e1b3fefd94854f46fcd9a412f641f7ed6
     folder: {{ name }}
 
 build:
   number: 0
-  skip: true  # [osx and x86_64]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
 


### PR DESCRIPTION
qttranslations 6.9.2

**Destination channel:** defaults

### Links

- [PKG-9668](https://anaconda.atlassian.net/browse/PKG-9668)
- [Upstream repository](https://github.com/qt/qttranslations/tree/v6.9.2)
- [Upstream changelog/diff](https://github.com/qt/qttranslations/compare/v6.9.1...v6.9.2)

[PKG-9668]: https://anaconda.atlassian.net/browse/PKG-9668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ